### PR TITLE
fixing missing class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,16 @@
 source 'https://rubygems.org'
 
-gem 'sinatra', '1.4.6'
+gem 'sinatra', '1.4.7'
 
-gem 'bson', '4.0.0'
-gem 'rdf', '1.99.1'
-gem 'rdf-vocab', '~> 0.8.7'
-gem 'sparql-client', '1.99.0', require: 'sparql/client'
+gem 'bson', '4.1.1'
+gem 'rdf', '2.0.1'
+gem 'rdf-vocab', '2.0.1'
+gem 'sparql-client', '2.0.0', require: 'sparql/client'
 
 group :test, :development do
-	gem 'rspec', '~> 3.4'
-	gem 'json_spec', '~> 1.1', '>= 1.1.4'
-	gem 'rack-test', '~> 0.6.3'
+ gem 'rspec', '~> 3.4'
+ gem 'json_spec', '~> 1.1', '>= 1.1.4'
+ gem 'rack-test', '~> 0.6.3'
 end
 
 Dir.glob(File.join(File.dirname(__FILE__), 'ext', '**', "Gemfile")) do |gemfile|


### PR DESCRIPTION
If an application running the ruby template is started, the first call that involves an RDF related library fails with a class not found exception. After that the class is loaded and the call succeeds. This is fixed in later versions of the library