### PR TITLE
make instance methods available as module functions

### DIFF
--- a/sinatra_template/helpers.rb
+++ b/sinatra_template/helpers.rb
@@ -81,4 +81,5 @@ module SinatraTemplate
       end
     end
   end
+  extend(self)
 end


### PR DESCRIPTION
This small change makes all helpers available to be called via `SinatraTemplate::Helpers.{method_name}`. A useful addition for classes that can not directly access the sinatra application