### PR TITLE
Compatibility with Sesame

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'sinatra', '1.4.7'
+gem 'sinatra-contrib', '1.4.7'
 
 gem 'bson', '4.0.0'
 gem 'linkeddata', '2.0.0'

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The template supports the following environment variables:
 
 - `MU_SPARQL_TIMEOUT` is used to configure the timeout (in seconds) for SPARQL queries.
 
+- `MU_SPARQL_UPDATE_ENDPOINT` is used to override the update endpoint for
+  update queries (i.e. if you want to use Sesame)
+
 ## Develop a microservice using the template
 To use the template while developing your app, start a container in development mode with your code folder mounted in `/app`:
 

--- a/sinatra_template/helpers.rb
+++ b/sinatra_template/helpers.rb
@@ -38,7 +38,7 @@ module SinatraTemplate
   
     def update(query)
       log.info "Executing query: #{query}"
-      settings.sparql_client.update query
+      settings.sparql_client.update query, { endpoint: settings.update_endpoint }
     end
   
     def update_modified(subject, modified = DateTime.now)

--- a/web.rb
+++ b/web.rb
@@ -19,6 +19,7 @@ configure do
     options[:read_timeout] = ENV['MU_SPARQL_TIMEOUT'].to_i
   end
   set :sparql_client, SPARQL::Client.new(ENV['MU_SPARQL_ENDPOINT'], options)
+  set :update_endpoint, ENV['MU_SPARQL_UPDATE_ENDPOINT'] || ENV['MU_SPARQL_ENDPOINT']
 
   ###
   # Logging


### PR DESCRIPTION
In brief what has been added in this PR:

1.  The possibility to specify a different endpoint for a query or an update
2.  Pre-imported some fixes because the feature 1. is buggy in sparql-client and another fix for compatibility with Sesame.

Fixes:
 *  [sparql-client #72](https://github.com/ruby-rdf/sparql-client/pull/72)
 *  [sparql-client #73](https://github.com/ruby-rdf/sparql-client/pull/73)