### PR TITLE
Setting timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ The SPARQL endpoint can be configured through the `MU_SPARQL_ENDPOINT` environme
 
 The `MU_APPLICATION_GRAPH` environment variable specifies the graph in the triple store the microservice will work in. By default this is set to `http://mu.semte.ch/application`. The graph name can be used in the service via `settings.graph`.
 
+The MU_SPARQL_TIMEOUT sets the timeout for SPARQL queries.
+
 ## Develop a microservice using the template
 To use the template while developing your app, start a container in development mode with your code folder mounted in `/app`:
 
     docker run --volume /path/to/your/code:/app
                 -e RACK_ENV=development
 	        -d semtech/mu-ruby-template:2.0.0-ruby2.3
-    
+
 Changes will be automatically picked up by Sinatra.
 
 To get the [Better Errors](https://github.com/charliesome/better_errors) working, you need to access your microservice directly instead of going through the identifier and dispatcher. You can retrieve your microservice's IP address by running the command: `docker inspect {container-name} | grep -i ip`.
@@ -74,7 +76,7 @@ To run the tests while developing, start an interactive container in the test en
     docker run --volume /path/to/your/code:/app
                 -e RACK_ENV=test
                 -it semtech/mu-ruby-template:1.2.0-ruby2.1 /bin/bash
-    
+
 You can now run your tests inside the container with:
 
     bundle install

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The SPARQL endpoint can be configured through the `MU_SPARQL_ENDPOINT` environme
 
 The `MU_APPLICATION_GRAPH` environment variable specifies the graph in the triple store the microservice will work in. By default this is set to `http://mu.semte.ch/application`. The graph name can be used in the service via `settings.graph`.
 
-The MU_SPARQL_TIMEOUT sets the timeout for SPARQL queries.
+The `MU_SPARQL_TIMEOUT` sets the timeout for SPARQL queries.
 
 ## Develop a microservice using the template
 To use the template while developing your app, start a container in development mode with your code folder mounted in `/app`:

--- a/web.rb
+++ b/web.rb
@@ -12,7 +12,11 @@ require_relative 'lib/escape_helpers.rb'
 
 configure do
   set :graph, ENV['MU_APPLICATION_GRAPH']
-  set :sparql_client, SPARQL::Client.new(ENV['MU_SPARQL_ENDPOINT'])
+  options = {}
+  if ENV['MU_SPARQL_TIMEOUT']
+    options[:read_timeout] = ENV['MU_SPARQL_TIMEOUT'].to_i
+  end
+  set :sparql_client, SPARQL::Client.new(ENV['MU_SPARQL_ENDPOINT'], options)
 
   ###
   # Logging


### PR DESCRIPTION
I added an environment variable to set the timeout for the SPARQL query. I chose `MU_SPARQL_TIMEOUT` as a name. Is this good?