### PR TITLE
update endpoint should be a relative uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The template supports the following environment variables:
 - `MU_SPARQL_TIMEOUT` is used to configure the timeout (in seconds) for SPARQL queries.
 
 - `MU_SPARQL_UPDATE_ENDPOINT` is used to override the update endpoint for
-  update queries (i.e. if you want to use Sesame)
+  update queries (i.e. if you want to use Sesame). Note this should be a path relative to the base of MU_SPARQL_ENDPOINT!
 
 ## Develop a microservice using the template
 To use the template while developing your app, start a container in development mode with your code folder mounted in `/app`:

--- a/web.rb
+++ b/web.rb
@@ -19,7 +19,7 @@ configure do
     options[:read_timeout] = ENV['MU_SPARQL_TIMEOUT'].to_i
   end
   set :sparql_client, SPARQL::Client.new(ENV['MU_SPARQL_ENDPOINT'], options)
-  set :update_endpoint, ENV['MU_SPARQL_UPDATE_ENDPOINT'] || ENV['MU_SPARQL_ENDPOINT']
+  set :update_endpoint, ENV['MU_SPARQL_UPDATE_ENDPOINT'] || RDF::URI.new(ENV['MU_SPARQL_ENDPOINT']).request_uri
 
   ###
   # Logging


### PR DESCRIPTION
I've checked the implementation of sparql-client and the update endpoint should be a relative uri.