### PR TITLE
Set Cache-Control: no-cache by default

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -16,6 +16,11 @@ configure do
   set :sparql_client, sparql_client
   set :update_endpoint, update_endpoint
   set :log, SinatraTemplate::Utils.log
+  before '*' do
+    # NOTE: all requests will defaults to no-cache like other frameworks like Hapi.
+    #       Every endpoint can still override this behavior separately.
+    response.headers['Cache-Control'] = 'no-cache'
+  end if ENV['NO_CACHE_CONTROL'].nil?
 end
 
 configure :development do


### PR DESCRIPTION
It's generally a good idea on an API to disable the cache. This will
prevent any proxy to cache the response of the API for instance. Some
frameworks like Hapi does it by default and allows you to deactivate
this behavior if requested.

https://github.com/hapijs/hapi/blob/master/API.md#route-options

This implementation allows you to override the Cache-Control header by
request and will always give you the possibility to remove this default
header entirely by setting the environment variable NO_CACHE_CONTROL.

Since the mu-ruby-template main purpose is to create API, this change
will prevent unexpected behaviors for the developers.

It is also more consistent with mu-javascript-template (which uses
Hapi).