### PR TITLE
Removed -c command from Rspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ To run the tests while developing, start an interactive container in the test en
 You can now run your tests inside the container with:
 
     bundle install
-    rspec -c
+    rspec
 
 ## Custom build commands
 To execute custom bash statements during the image build (e.g. to install aditional system libraries), provide an `on-build.sh` script in the root of your service. It will be automatically picked up and executed by the Docker build.


### PR DESCRIPTION
By looking at Rspec itself, it doesn't have a `-c` parameter in it's `--help`.

Also the shell script that runs the test commands doesn't do `-c` either, see:
https://github.com/erikap/docker-ruby-sinatra/blob/master/startup.sh#L11

---
Other, might be related question:
Is it intended to run the template's tests too when we are testing a microservice? I wrote 10 tests for a microservice that uses this template. When I run the suggested `docker run --rm -e RACK_ENV=test microservice-image` command I get `13 examples 0 failures`.

The extra 3 tests can be found here: 
https://github.com/mu-semtech/mu-ruby-template/blob/master/spec/helper_spec.rb

When I `-it /bin/bash` into the docker and run the tests manually, In the `/usr/src/app` folder I get 13, in the `/usr/src/app/ext` folder I get 10 tests. So it is a bit confusing to have that extra 3 tests.
