### PR TITLE
Jruby support

### DIFF
--- a/Dockerfile.jruby
+++ b/Dockerfile.jruby
@@ -1,0 +1,38 @@
+FROM jruby:9
+
+ENV APP_ENTRYPOINT web.rb
+ENV LOG_LEVEL info
+ENV MU_SPARQL_ENDPOINT 'http://database:8890/sparql'
+ENV MU_APPLICATION_GRAPH 'http://mu.semte.ch/application'
+ENV TRUSTED_IP 0.0.0.0/0
+
+
+ENV RACK_ENV production
+ENV MAIN_APP_FILE web.rb
+RUN mkdir -p /usr/src/app
+ADD startup.sh /
+WORKDIR /usr/src/app
+
+EXPOSE 80
+
+CMD ["/bin/bash", "/startup.sh"]
+ADD . /usr/src/app
+
+RUN gem install bundler && gem uninstall bundler -i /opt/jruby/lib/ruby/gems/shared --version '<2.0.0' # quirk in jruby that has old bundled version of bundler
+RUN ln -s /app /usr/src/app/ext \
+     && ln -s /app/spec /usr/src/app/spec/ext \
+     && mkdir /logs \
+     && touch /logs/application.log \
+     && ln -sf /dev/stdout /logs/application.log \
+     && cd /usr/src/app \
+     && bundle install
+
+ONBUILD ADD . /app/
+ONBUILD RUN if [ -f /app/on-build.sh ]; \
+     then \
+        echo "Running custom on-build.sh of child" \
+        && chmod +x /app/on-build.sh \
+        && /bin/bash /app/on-build.sh ;\
+     fi
+ONBUILD RUN cd /usr/src/app \
+     && bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'sinatra', '1.4.8'
 gem 'sinatra-contrib', '1.4.7'
 
 gem 'bson', '4.0.0'
-gem 'linkeddata', '3.0.1'
+gem 'linkeddata', '3.0.0'
 gem 'request_store', '1.4.1'
 
 group :test, :development do
@@ -13,7 +13,7 @@ group :test, :development do
   gem 'rack-test', '~> 0.6.3'
   gem 'pry'
   gem 'better_errors'
-  gem 'binding_of_caller'
+  gem 'binding_of_caller', :platforms => :ruby
 end
 
 Dir.glob(File.join(File.dirname(__FILE__), 'ext', '**', "Gemfile")) do |gemfile|

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ gem 'sinatra', '1.4.8'
 gem 'sinatra-contrib', '1.4.7'
 
 gem 'bson', '4.0.0'
-gem 'linkeddata', '3.0.0'
+gem 'sparql-client', '3.0.1'
+gem 'rdf-vocab', '3.0.8'
 gem 'request_store', '1.4.1'
 
 group :test, :development do

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+if [ "$RACK_ENV" == "production" ];
+then
+    bundle install --without development test
+    bundle exec ruby --server $MAIN_APP_FILE -p 80
+else
+    bundle install
+    if [ "$RACK_ENV" == "test" ];
+    then
+        bundle exec rspec
+    else
+        bundle exec ruby --dev $MAIN_APP_FILE -p 80 -o '0.0.0.0'
+    fi
+fi


### PR DESCRIPTION
This pull requests adds support for jruby in the tempate.

- A second dockerfile was added which installs the necessary dependencies and runs the startup script
- `startup.sh` was added as an entrypoint for the jruby dockerfile. It's mostly a copy from https://github.com/erikap/docker-ruby-sinatra/blob/master/startup.sh 
- The Gemfile was modified for jruby support. Since not all dependencies of the linked data gem are supported under jruby it was replaced with the 2 gems the template uses: rdf-vocab and sparql-client. If more libraries are required by consuming services they
can either add their own Gemfile with linkeddata or (probably recommended)
include the specific ruby-rdf gems they require. 

This PR was tested as a ruby template succesfully on the file-service, jruby was tested on the mock-login-service.