### PR TITLE
allow specification of JRUBY_OPTIONS to pass extra options to jruby

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -2,13 +2,13 @@
 if [ "$RACK_ENV" == "production" ];
 then
     bundle install --without development test
-    bundle exec ruby --server $MAIN_APP_FILE -p 80
+    bundle exec ruby $JRUBY_OPTIONS --server $MAIN_APP_FILE -p 80
 else
     bundle install
     if [ "$RACK_ENV" == "test" ];
     then
         bundle exec rspec
     else
-        bundle exec ruby --dev $MAIN_APP_FILE -p 80 -o '0.0.0.0'
+        bundle exec ruby $JRUBY_OPTIONS --dev $MAIN_APP_FILE -p 80 -o '0.0.0.0'
     fi
 fi


### PR DESCRIPTION
This PR allows the specification of additional parameters that are passed on to jruby, for example to set the maximum heap space.

example usage: `docker run -e JRUBY_OPTIONS="-J-Xmx32g" ...`