### PR TITLE
only set allowed and used groups headers when required

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -72,10 +72,18 @@ end
 after do
   auth_headers = {}
   if RequestStore.store[:mu_auth_allowed_groups]
-    auth_headers['mu-auth-allowed-groups'] = RequestStore.store[:mu_auth_allowed_groups]
+    if headers['mu-auth-allowed-groups']
+      log.info "ruby template: not setting allowed groups because header already provided with value #{headers['mu-auth-allowed-groups'].inspect}"
+    else
+      auth_headers['mu-auth-allowed-groups'] = RequestStore.store[:mu_auth_allowed_groups]
+    end
   end
   if RequestStore.store[:mu_auth_used_groups]
-    auth_headers['mu-auth-used-groups'] = RequestStore.store[:mu_auth_used_groups]
+    if headers['mu-auth-used-groups']
+      log.info "ruby template: not setting used groups because header already provided with value #{headers['mu-auth-used-groups'].inspect}"
+    else
+      auth_headers['mu-auth-used-groups'] = RequestStore.store[:mu_auth_used_groups]
+    end
   end
   headers auth_headers
 end


### PR DESCRIPTION
some services (typically login service) will set these headers themselves and we
should not overwrite the provided value.

I added an info message to make clear when this happens as it should be an
exceptional case.