### PR TITLE
Install netbase package as part of JRuby template

### DIFF
--- a/Dockerfile.jruby
+++ b/Dockerfile.jruby
@@ -1,5 +1,10 @@
 FROM jruby:9.2
 
+# Prevent services from freaking out when loading "native protocols db"
+RUN apt-get update \
+  && apt-get install -y netbase --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
 ENV APP_ENTRYPOINT web.rb
 ENV LOG_LEVEL info
 ENV MU_SPARQL_ENDPOINT 'http://database:8890/sparql'


### PR DESCRIPTION
This package is needed to quiet down a warning & stacktrace printed by the underlying Java process.

I noticed that on the latest `mu-search` beta template on each boot (after the indexes have been initialized) the following would be printed:

```
search_1  | 2023-07-14T07:17:01.950014992Z Jul 14, 2023 7:17:01 AM jnr.netdb.NativeProtocolsDB load
search_1  | 2023-07-14T07:17:01.950049449Z WARNING: Failed to load native protocols db
search_1  | 2023-07-14T07:17:01.950054428Z java.lang.RuntimeException: getprotobyname_r failed
search_1  | 2023-07-14T07:17:01.950057531Z 	at jnr.netdb.NativeProtocolsDB$LinuxNativeProtocolsDB.getProtocolByName(NativeProtocolsDB.java:180)
search_1  | 2023-07-14T07:17:01.950060583Z 	at jnr.netdb.NativeProtocolsDB.load(NativeProtocolsDB.java:80)
search_1  | 2023-07-14T07:17:01.950063517Z 	at jnr.netdb.NativeProtocolsDB.access$000(NativeProtocolsDB.java:40)
search_1  | 2023-07-14T07:17:01.950066518Z 	at jnr.netdb.NativeProtocolsDB$SingletonHolder.<clinit>(NativeProtocolsDB.java:47)
search_1  | 2023-07-14T07:17:01.950081575Z 	at jnr.netdb.NativeProtocolsDB.getInstance(NativeProtocolsDB.java:43)
search_1  | 2023-07-14T07:17:01.950084337Z 	at jnr.netdb.Protocol$ProtocolDBSingletonHolder.load(Protocol.java:107)
search_1  | 2023-07-14T07:17:01.950087127Z 	at jnr.netdb.Protocol$ProtocolDBSingletonHolder.<clinit>(Protocol.java:103)
search_1  | 2023-07-14T07:17:01.950089973Z 	at jnr.netdb.Protocol.getProtocolDB(Protocol.java:96)
search_1  | 2023-07-14T07:17:01.950092688Z 	at jnr.netdb.Protocol.getProtocolByNumber(Protocol.java:59)
search_1  | 2023-07-14T07:17:01.950095460Z 	at org.jruby.ext.socket.Addrinfo.<init>(Addrinfo.java:806)
search_1  | 2023-07-14T07:17:01.950098434Z 	at org.jruby.ext.socket.SocketUtils$2.addrinfo(SocketUtils.java:255)
search_1  | 2023-07-14T07:17:01.950101298Z 	at org.jruby.ext.socket.SocketUtils.buildAddrinfoList(SocketUtils.java:321)
search_1  | 2023-07-14T07:17:01.950104191Z 	at org.jruby.ext.socket.SocketUtils.getaddrinfoList(SocketUtils.java:231)
search_1  | 2023-07-14T07:17:01.950107120Z 	at org.jruby.ext.socket.Addrinfo.getaddrinfo(Addrinfo.java:307)
search_1  | 2023-07-14T07:17:01.950144887Z 	at org.jruby.ext.socket.Addrinfo$INVOKER$s$0$0$getaddrinfo.call(Addrinfo$INVOKER$s$0$0$getaddrinfo.gen)
search_1  | 2023-07-14T07:17:01.950150722Z 	at org.jruby.internal.runtime.methods.JavaMethod$JavaMethodN.call(JavaMethod.java:837)
search_1  | 2023-07-14T07:17:01.950154084Z 	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:333)
search_1  | 2023-07-14T07:17:01.950157325Z 	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:87)
search_1  | 2023-07-14T07:17:01.950161035Z 	at org.jruby.ir.instructions.CallBase.interpret(CallBase.java:549)
search_1  | 2023-07-14T07:17:01.950164023Z 	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:361)
search_1  | 2023-07-14T07:17:01.950167054Z 	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
search_1  | 2023-07-14T07:17:01.950170503Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:86)
search_1  | 2023-07-14T07:17:01.950178904Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:73)
search_1  | 2023-07-14T07:17:01.950181459Z 	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:333)
search_1  | 2023-07-14T07:17:01.950185483Z 	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:87)
search_1  | 2023-07-14T07:17:01.950188762Z 	at org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:94)
search_1  | 2023-07-14T07:17:01.950191681Z 	at org.jruby.ir.instructions.CallBase.interpret(CallBase.java:546)
search_1  | 2023-07-14T07:17:01.950194432Z 	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:361)
search_1  | 2023-07-14T07:17:01.950197073Z 	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
search_1  | 2023-07-14T07:17:01.950199855Z 	at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:92)
search_1  | 2023-07-14T07:17:01.950202498Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:191)
search_1  | 2023-07-14T07:17:01.950205126Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:178)
search_1  | 2023-07-14T07:17:01.950207700Z 	at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:208)
search_1  | 2023-07-14T07:17:01.950210379Z 	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:397)
search_1  | 2023-07-14T07:17:01.950213094Z 	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:206)
search_1  | 2023-07-14T07:17:01.950216019Z 	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:325)
search_1  | 2023-07-14T07:17:01.950218642Z 	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
search_1  | 2023-07-14T07:17:01.950221291Z 	at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:92)
search_1  | 2023-07-14T07:17:01.950224040Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:191)
search_1  | 2023-07-14T07:17:01.950232056Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:178)
search_1  | 2023-07-14T07:17:01.950235403Z 	at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:208)
search_1  | 2023-07-14T07:17:01.950238409Z 	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:397)
search_1  | 2023-07-14T07:17:01.950241202Z 	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:206)
search_1  | 2023-07-14T07:17:01.950243806Z 	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:325)
search_1  | 2023-07-14T07:17:01.950246409Z 	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
search_1  | 2023-07-14T07:17:01.950249219Z 	at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:92)
search_1  | 2023-07-14T07:17:01.950251943Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:191)
search_1  | 2023-07-14T07:17:01.950254985Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:178)
search_1  | 2023-07-14T07:17:01.950257892Z 	at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:208)
search_1  | 2023-07-14T07:17:01.950260510Z 	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:397)
search_1  | 2023-07-14T07:17:01.950263106Z 	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:206)
search_1  | 2023-07-14T07:17:01.950265655Z 	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:325)
search_1  | 2023-07-14T07:17:01.950268213Z 	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
search_1  | 2023-07-14T07:17:01.950270865Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:86)
search_1  | 2023-07-14T07:17:01.950273511Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:73)
search_1  | 2023-07-14T07:17:01.950276021Z 	at org.jruby.ir.runtime.IRRuntimeHelpers.instanceSuper(IRRuntimeHelpers.java:1169)
search_1  | 2023-07-14T07:17:01.950278542Z 	at org.jruby.ir.instructions.InstanceSuperInstr.interpret(InstanceSuperInstr.java:84)
search_1  | 2023-07-14T07:17:01.950281170Z 	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:361)
search_1  | 2023-07-14T07:17:01.950283918Z 	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
search_1  | 2023-07-14T07:17:01.950286543Z 	at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:86)
search_1  | 2023-07-14T07:17:01.950289427Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:156)
search_1  | 2023-07-14T07:17:01.950293648Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:143)
search_1  | 2023-07-14T07:17:01.950296683Z 	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:387)
search_1  | 2023-07-14T07:17:01.950300063Z 	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:185)
search_1  | 2023-07-14T07:17:01.950306827Z 	at org.jruby.RubyClass.newInstance(RubyClass.java:918)
search_1  | 2023-07-14T07:17:01.950310044Z 	at org.jruby.RubyClass$INVOKER$i$newInstance.call(RubyClass$INVOKER$i$newInstance.gen)
search_1  | 2023-07-14T07:17:01.950313020Z 	at org.jruby.internal.runtime.methods.JavaMethod$JavaMethodZeroOrOneOrNBlock.call(JavaMethod.java:349)
search_1  | 2023-07-14T07:17:01.950337559Z 	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:376)
search_1  | 2023-07-14T07:17:01.950341222Z 	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:175)
search_1  | 2023-07-14T07:17:01.950344488Z 	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:316)
search_1  | 2023-07-14T07:17:01.950348404Z 	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
search_1  | 2023-07-14T07:17:01.950351646Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:86)
search_1  | 2023-07-14T07:17:01.950355028Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:73)
search_1  | 2023-07-14T07:17:01.950358534Z 	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:333)
search_1  | 2023-07-14T07:17:01.950361912Z 	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:87)
search_1  | 2023-07-14T07:17:01.950364877Z 	at org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:94)
search_1  | 2023-07-14T07:17:01.950367836Z 	at org.jruby.ir.instructions.CallBase.interpret(CallBase.java:546)
search_1  | 2023-07-14T07:17:01.950371721Z 	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:361)
search_1  | 2023-07-14T07:17:01.950374284Z 	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
search_1  | 2023-07-14T07:17:01.950377067Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:86)
search_1  | 2023-07-14T07:17:01.950379753Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:73)
search_1  | 2023-07-14T07:17:01.950382367Z 	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:333)
search_1  | 2023-07-14T07:17:01.950384963Z 	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:87)
search_1  | 2023-07-14T07:17:01.950387763Z 	at org.jruby.ir.instructions.CallBase.interpret(CallBase.java:549)
search_1  | 2023-07-14T07:17:01.950392444Z 	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:361)
search_1  | 2023-07-14T07:17:01.950394944Z 	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
search_1  | 2023-07-14T07:17:01.950403696Z 	at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:80)
search_1  | 2023-07-14T07:17:01.950406391Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:121)
search_1  | 2023-07-14T07:17:01.950409206Z 	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:108)
search_1  | 2023-07-14T07:17:01.950412050Z 	at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:192)
search_1  | 2023-07-14T07:17:01.950420874Z 	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:355)
search_1  | 2023-07-14T07:17:01.950424361Z 	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:144)
search_1  | 2023-07-14T07:17:01.950427501Z 	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:345)
search_1  | 2023-07-14T07:17:01.950430384Z 	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
search_1  | 2023-07-14T07:17:01.950433759Z 	at org.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:116)
search_1  | 2023-07-14T07:17:01.950436720Z 	at org.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:137)
search_1  | 2023-07-14T07:17:01.950439448Z 	at org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:60)
search_1  | 2023-07-14T07:17:01.950442094Z 	at org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:52)
search_1  | 2023-07-14T07:17:01.950444746Z 	at org.jruby.runtime.Block.call(Block.java:139)
search_1  | 2023-07-14T07:17:01.950447322Z 	at org.jruby.RubyProc.call(RubyProc.java:318)
search_1  | 2023-07-14T07:17:01.950451060Z 	at org.jruby.Ruby.tearDown(Ruby.java:3150)
search_1  | 2023-07-14T07:17:01.950453693Z 	at org.jruby.Ruby.tearDown(Ruby.java:3123)
search_1  | 2023-07-14T07:17:01.950456357Z 	at org.jruby.Main.internalRun(Main.java:296)
search_1  | 2023-07-14T07:17:01.950459001Z 	at org.jruby.Main.run(Main.java:234)
search_1  | 2023-07-14T07:17:01.950461508Z 	at org.jruby.Main.main(Main.java:206)
search_1  | 2023-07-14T07:17:01.950464710Z 
search_1  | 2023-07-14T07:17:01.957544672Z == Sinatra (v1.4.8) has taken the stage on 80 for production with backup from WEBrick
search_1  | 2023-07-14T07:17:01.960542591Z [2023-07-14 07:17:01] INFO  WEBrick::HTTPServer#start: pid=1 port=80
```

The actual working of the service doesn't seem impacted, but according to https://github.com/jruby/jruby/issues/3955 this issue should be resolved by installing a package (on Ubuntu systems), which seems to be true because the warning & stacktrace are gone after installing the package.