### PR TITLE
setup arm64 builds

### DIFF
--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -2,7 +2,7 @@ pipeline:
   build-and-push:
     image: woodpeckerci/plugin-docker-buildx
     settings:
-      platforms: linux/amd64
+      platforms: linux/amd64, linux/arm64
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}"
       tags: "feature-${CI_COMMIT_BRANCH##feature/}"
     secrets: [docker_username, docker_password]
@@ -10,7 +10,7 @@ pipeline:
   build-and-push-jruby:
     image: woodpeckerci/plugin-docker-buildx
     settings:
-      platforms: linux/amd64
+      platforms: linux/amd64, linux/arm64
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME/ruby/jruby}"
       tags: "feature-${CI_COMMIT_BRANCH##feature/}"
       dockerfile: Dockerfile.jruby

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -2,7 +2,7 @@ pipeline:
   build-and-push:
     image: woodpeckerci/plugin-docker-buildx
     settings:
-      platforms: linux/amd64
+      platforms: linux/amd64, linux/arm64
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}"
       tags: latest
     secrets: [docker_username, docker_password]
@@ -10,7 +10,7 @@ pipeline:
   build-and-push-jruby:
     image: woodpeckerci/plugin-docker-buildx
     settings:
-      platforms: linux/amd64
+      platforms: linux/amd64, linux/arm64
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME/ruby/jruby}"
       tags: latest
       dockerfile: Dockerfile.jruby

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,15 +1,16 @@
 pipeline:
   release:
-    image: plugins/docker
+    image: woodpeckerci/plugin-docker-buildx
     settings:
+      platforms: linux/amd64, linux/arm64
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}"
       tags: "${CI_COMMIT_TAG##v}"
-    secrets: [ docker_username, docker_password ]
+    secrets: [docker_username, docker_password]
     group: build
   build-and-push-jruby:
     image: woodpeckerci/plugin-docker-buildx
     settings:
-      platforms: linux/amd64
+      platforms: linux/amd64, linux/arm64
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME/ruby/jruby}"
       tags: "${CI_COMMIT_TAG##v}"
       dockerfile: Dockerfile.jruby


### PR DESCRIPTION
base images for ruby 3.2 and jruby 9.4 support arm64 so we can start building them too.